### PR TITLE
Remove undesired "else:"

### DIFF
--- a/src/TorchSisso/model.py
+++ b/src/TorchSisso/model.py
@@ -56,7 +56,7 @@ class SissoModel:
         
     else: self.dimension = n_term
         
-    else: self.sis_features = k
+    self.sis_features = k
     
     self.relational_units = relational_units
     


### PR DESCRIPTION
I got an error message stating "invalid syntax (model.py, line 59"). The "else:" seems unnecessary.